### PR TITLE
Fix double edge issue

### DIFF
--- a/src/canvas/canvasReducer.ts
+++ b/src/canvas/canvasReducer.ts
@@ -266,7 +266,9 @@ const connectAtomsMiddleware: Middleware = ({ getState, dispatch }) => {
     if (shouldConnect) {
       const sourceId = getState().canvas.pressedAtomId;
       const targetId = action.payload.atomId;
-      dispatch(connectAtoms(sourceId, targetId));
+      if (sourceId != targetId) {
+        dispatch(connectAtoms(sourceId, targetId));
+      }
     }
 
     next(action);


### PR DESCRIPTION
Due to the logic of click handling. Code was sending connect action
to reducer where `sourceId` and `targetId` were the same.

Fixes: #19 